### PR TITLE
Apply kubectl at directory level

### DIFF
--- a/modules/02-traffic-management/README.md
+++ b/modules/02-traffic-management/README.md
@@ -24,7 +24,7 @@ subset configuration thereby leading to a uniform traffic spread across both sub
 cd ../02-traffic-management
 
 # Install the mesh resources
-kubectl apply -f './setup-mesh-resources/*.yaml'
+kubectl apply -f ./setup-mesh-resources/
 ```
 
 Output should be similar to:
@@ -444,7 +444,7 @@ applied on [`productcatalog`](./shift-traffic-v2-header/productcatalog-envoyfilt
 ```bash
 # Update route to add a match on user-type header
 # and install a filter to set the header
-kubectl apply -f './shift-traffic-v2-header/*.yaml'
+kubectl apply -f ./shift-traffic-v2-header/
 ```
 
 Output should be similar to:


### PR DESCRIPTION
*Issue #, if available:* Some shell interpreters weren't able to parse file glob patterns for kubectl apply.

*Description of changes:* Changed kubectl apply from file glob pattern to directory level.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
