### PR TITLE
Updated to istio 2.6 and to EKS Auto Mode

### DIFF
--- a/modules/01-getting-started/values.yaml
+++ b/modules/01-getting-started/values.yaml
@@ -4,17 +4,17 @@
 
 catalogdetail1:
   image:
-    repository: public.ecr.aws/u2g6w7p2/eks-workshop-demo/catalog_detail
+    repository: public.ecr.aws/u0x7j7d5/istio-on-eks/catalog_detail
     tag: "1.0"
 
 catalogdetail2:
   image:
-    repository: public.ecr.aws/u2g6w7p2/eks-workshop-demo/catalog_detail
+    repository: public.ecr.aws/u0x7j7d5/istio-on-eks/catalog_detail
     tag: "2.0"
 
 productcatalog:
   image:
-    repository: public.ecr.aws/u2g6w7p2/eks-workshop-demo/product_catalog
+    repository: public.ecr.aws/u0x7j7d5/istio-on-eks/product_catalog
     tag: "1.0"
 
   env:
@@ -23,7 +23,7 @@ productcatalog:
 
 frontend:
   image:
-    repository: public.ecr.aws/u2g6w7p2/eks-workshop-demo/frontend_node
+    repository: public.ecr.aws/u0x7j7d5/istio-on-eks/frontend_node
     tag: "2.0"
 
   env:

--- a/terraform-blueprint/sidecar/README.md
+++ b/terraform-blueprint/sidecar/README.md
@@ -14,6 +14,8 @@ Refer to the [Istio documentation](https://istio.io/latest/docs/concepts/) for d
 
 Refer to the [prerequisites](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) and run the following command to deploy this pattern:
 
+> ✅ Note: The EKS clusters created for this usecase will use EKS Auto Mode
+
 ```sh
 terraform init
 terraform apply --auto-approve
@@ -33,7 +35,7 @@ cluster with deployed Istio.
 ```sh
 for ADDON in kiali jaeger prometheus grafana
 do
-    ADDON_URL="https://raw.githubusercontent.com/istio/istio/release-1.22/samples/addons/$ADDON.yaml"
+    ADDON_URL="https://raw.githubusercontent.com/istio/istio/release-1.26/samples/addons/$ADDON.yaml"
     kubectl apply -f $ADDON_URL
 done
 ```

--- a/terraform-blueprint/sidecar/main.tf
+++ b/terraform-blueprint/sidecar/main.tf
@@ -38,7 +38,7 @@ locals {
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
   istio_chart_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_chart_version = "1.22.0"
+  istio_chart_version = "1.26.1"
 
   tags = {
     Blueprint  = local.name
@@ -52,34 +52,23 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.11"
+  version = "~> 20.36.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.30"
+  cluster_version                = "1.33"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
-  cluster_addons = {
-    coredns    = {}
-    kube-proxy = {}
-    vpc-cni    = {}
+  cluster_compute_config = {
+    enabled    = true
+    node_pools = ["general-purpose"]
   }
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-
-  eks_managed_node_groups = {
-    initial = {
-      instance_types = ["m5.large"]
-
-      min_size     = 1
-      max_size     = 5
-      desired_size = 2
-    }
-  }
 
   #  EKS K8s API cluster needs to be able to talk with the EKS worker nodes with port 15017/TCP and 15012/TCP which is used by Istio
   #  Istio in order to create sidecar needs to be able to communicate with webhook and for that network passage to EKS is needed.
@@ -117,15 +106,12 @@ resource "kubernetes_namespace_v1" "istio_system" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.16"
+  version = "~> 1.21.0"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
   cluster_version   = module.eks.cluster_version
   oidc_provider_arn = module.eks.oidc_provider_arn
-
-  # This is required to expose Istio Ingress Gateway
-  enable_aws_load_balancer_controller = true
 
   helm_releases = {
     istio-base = {
@@ -188,7 +174,7 @@ module "eks_blueprints_addons" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 5.21.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/terraform-blueprint/sidecar/versions.tf
+++ b/terraform-blueprint/sidecar/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.99.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.17.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 2.37.1"
     }
   }
 


### PR DESCRIPTION
## Solves the issue #110 

### Description of changes:
1. Updated terraform versions
2. Changed from Managed Node Groups to EKS Auto Mode for `sidecar` mode terraform blueprint
3. Updated Istio version from 1.22 to 1.26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
