### PR TITLE
Automation for a zero-downtime Root CA certificate rotation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ terraform.rc
 *.hcl
 
 *.bak
+.ansible/

--- a/patterns/multi-cluster-multi-primary/cert-rotation/README.md
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/README.md
@@ -1,0 +1,42 @@
+# Root CA Certificate Rotation - Istio on EKS
+
+This folder can be used to rotate the Root CA certificates on single cluster
+or Multi-cluster Istio Service Mesh.
+
+## Prerequisites 
+
+The following tools must be installed or available for use:
+1. Ansible v2.18.6
+2. Python v3.13.5
+
+> **Note:** This certificate rotation utility assumes you are using the EKS clusters
+> provided by the modules in the parent folder
+
+## Certificate Rotation on Single Cluster Mesh
+
+Edit the file [host_vars/localhost](host_vars/localhost) and update the entry 
+with the key `eks_ctx` by replacing `XXXXXXXXXXXX` with your AWS account number.
+
+Run the provided Ansible playbook by running the command:
+
+```sh
+ansible-playbook single-cluster.yaml 
+```
+
+## Certificate Rotation on Multi-Cluster Mesh 
+
+Edit the file [host_vars/localhost](host_vars/localhost) and update the entry 
+with the key `eks_1_ctx` and `eks_2_ctx` by replacing `XXXXXXXXXXXX` with your 
+AWS account number.
+
+Run the provided Ansible playbook by running the command:
+
+```sh
+ansible-playbook multi-cluster.yaml 
+```
+
+### Verification
+
+You can use the script [scripts/check-workload-certificate.sh](scripts/check-workload-certificate.sh)
+before and after the certificate rotation to verify if the certificates have
+been picked up.

--- a/patterns/multi-cluster-multi-primary/cert-rotation/files/.gitignore
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/files/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/patterns/multi-cluster-multi-primary/cert-rotation/host_vars/localhost
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/host_vars/localhost
@@ -1,0 +1,3 @@
+eks_1_ctx: "arn:aws:eks:us-west-2:XXXXXXXXXXXX:cluster/eks-1"
+eks_2_ctx: "arn:aws:eks:us-west-2:XXXXXXXXXXXX:cluster/eks-2"
+eks_ctx: "arn:aws:eks:us-west-2:XXXXXXXXXXXX:cluster/eks-cluster-1"

--- a/patterns/multi-cluster-multi-primary/cert-rotation/multi-cluster.yaml
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/multi-cluster.yaml
@@ -19,7 +19,7 @@
       ansible.builtin.copy:
         dest: files/eks_1_cacerts_secret.yaml
         content: "{{ eks_1_cacerts_secret.result }}"
-        mode: '0755'
+        mode: '0600'
     - name: Ensure that the cacerts secret in istio-system exists in EKS 2
       kubernetes.core.k8s:
         state: present
@@ -33,7 +33,7 @@
       ansible.builtin.copy:
         dest: files/eks_2_cacerts_secret.yaml
         content: "{{ eks_2_cacerts_secret.result }}"
-        mode: '0755'
+        mode: '0600'
     # --------------------------------------------------------------------------
     # Create a new private key and a self-signed cert
     # --------------------------------------------------------------------------

--- a/patterns/multi-cluster-multi-primary/cert-rotation/multi-cluster.yaml
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/multi-cluster.yaml
@@ -1,0 +1,126 @@
+# This playbook would rotate the CA certs on two EKS clusters on which the
+# Istio multicluster mesh is running
+- name: Istio on EKS CA Cert Rotation
+  hosts: localhost
+  tasks:
+    # --------------------------------------------------------------------------
+    # Capture the cacerts secrets in the istio-system namespace of each cluster
+    # --------------------------------------------------------------------------
+    - name: Ensure that the cacerts secret in istio-system exists in EKS 1
+      kubernetes.core.k8s:
+        state: present
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_1_ctx }}"
+      register: eks_1_cacerts_secret
+    - name: Capture the cacerts secret in istio-system exists in EKS 1
+      ansible.builtin.copy:
+        dest: files/eks_1_cacerts_secret.yaml
+        content: "{{ eks_1_cacerts_secret.result }}"
+        mode: '0755'
+    - name: Ensure that the cacerts secret in istio-system exists in EKS 2
+      kubernetes.core.k8s:
+        state: present
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_2_ctx }}"
+      register: eks_2_cacerts_secret
+    - name: Capture the cacerts secret in istio-system exists in EKS 2
+      ansible.builtin.copy:
+        dest: files/eks_2_cacerts_secret.yaml
+        content: "{{ eks_2_cacerts_secret.result }}"
+        mode: '0755'
+    # --------------------------------------------------------------------------
+    # Create a new private key and a self-signed cert
+    # --------------------------------------------------------------------------
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: files/root-cert.key
+    - name: Create certificate signing request (CSR) for self-signed certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: files/root-cert.key
+        common_name: multicluster.istio.io
+      register: csr
+    - name: Create self-signed certificate from CSR
+      community.crypto.x509_certificate:
+        path: files/root-cert.pem
+        csr_content: "{{ csr.csr }}"
+        privatekey_path: files/root-cert.key
+        provider: selfsigned
+    # --------------------------------------------------------------------------
+    # Create a new root certificate by merging existing root cert with newly
+    # created root certificate
+    # --------------------------------------------------------------------------
+    - name: Display the EKS root-cert.pem
+      ansible.builtin.debug:
+        msg: "{{ eks_1_cacerts_secret.result.data[\"root-cert.pem\"] | b64decode }}"
+        verbosity: 1
+    - name: Capture the EKS root-cert.pem as string
+      ansible.builtin.set_fact:
+        eks_root_cert: "{{ eks_1_cacerts_secret.result.data[\"root-cert.pem\"] | b64decode }}"
+    - name: Capture the new root-cert.pem as string
+      ansible.builtin.set_fact:
+        new_root_cert: "{{ lookup('file', 'files/root-cert.pem') }}"
+    - name: Create a new certificate by concatenating the above two strings
+      ansible.builtin.copy:
+        dest: files/new-root-cert.pem
+        content: "{{ eks_root_cert + new_root_cert }}"
+        mode: '0400'
+    # --------------------------------------------------------------------------
+    # Replace the cacerts in istio-system namespace in EKS 1
+    # --------------------------------------------------------------------------
+    - name: Ensure that the cacerts secret in istio-system doesn't exist in EKS 1
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_1_ctx }}"
+    - name: Create the cacerts in istio-system namespace in EKS 1
+      kubernetes.core.k8s:
+        state: present
+        context: "{{ eks_1_ctx }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: cacerts
+            namespace: istio-system
+          data:
+            ca-cert.pem: "{{ eks_1_cacerts_secret.result.data[\"ca-cert.pem\"] }}"
+            ca-key.pem: "{{ eks_1_cacerts_secret.result.data[\"ca-key.pem\"] }}"
+            cert-chain.pem: "{{ eks_1_cacerts_secret.result.data[\"cert-chain.pem\"] }}"
+            root-cert.pem: "{{ lookup('file', 'files/new-root-cert.pem') | b64encode }}"
+    # --------------------------------------------------------------------------
+    # Replace the cacerts in istio-system namespace in EKS 2
+    # --------------------------------------------------------------------------
+    - name: Ensure that the cacerts secret in istio-system doesn't exist in EKS 2
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_2_ctx }}"
+    - name: Create the cacerts in istio-system namespace in EKS 2
+      kubernetes.core.k8s:
+        state: present
+        context: "{{ eks_2_ctx }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: cacerts
+            namespace: istio-system
+          data:
+            ca-cert.pem: "{{ eks_2_cacerts_secret.result.data[\"ca-cert.pem\"] }}"
+            ca-key.pem: "{{ eks_2_cacerts_secret.result.data[\"ca-key.pem\"] }}"
+            cert-chain.pem: "{{ eks_2_cacerts_secret.result.data[\"cert-chain.pem\"] }}"
+            root-cert.pem: "{{ lookup('file', 'files/new-root-cert.pem') | b64encode }}"

--- a/patterns/multi-cluster-multi-primary/cert-rotation/requirements.yml
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/requirements.yml
@@ -1,0 +1,8 @@
+collections:
+  # Install a collection from Ansible Galaxy.
+  - name: kubernetes.core
+    version: ">=5.3.0"
+    source: https://galaxy.ansible.com
+  - name: community.crypto
+    version: ">=2.26.1"
+    source: https://galaxy.ansible.com

--- a/patterns/multi-cluster-multi-primary/cert-rotation/scripts/check-workload-certificate.sh
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/scripts/check-workload-certificate.sh
@@ -1,0 +1,15 @@
+#!/bin/sh 
+
+set -e
+
+source `dirname "$(realpath $0)"`/set-cluster-contexts.sh $1 $2
+
+for ctx in $CTX_CLUSTER1 $CTX_CLUSTER2
+do 
+    echo ">> Getting the root certificate for helloworld pod in $ctx cluster\n"
+    POD_NAME=`kubectl --context "$ctx" get po -l app=helloworld -n sample -o json | jq -r ".items[0].metadata.name"`
+    istioctl --context "$ctx" pc secret $POD_NAME -n sample -o json |\
+        jq '[.dynamicActiveSecrets[] | select(.name == "ROOTCA")][0].secret.validationContext.trustedCa.inlineBytes' -r |\
+        base64 -d
+    echo "\n"
+done

--- a/patterns/multi-cluster-multi-primary/cert-rotation/scripts/set-cluster-contexts.sh
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/scripts/set-cluster-contexts.sh
@@ -1,0 +1,10 @@
+#!/bin/sh 
+
+CLUSTER_1_NAME=${1:-eks-1}
+CLUSTER_2_NAME=${2:-eks-2}
+
+aws eks update-kubeconfig --region us-west-2 --name $CLUSTER_1_NAME
+aws eks update-kubeconfig --region us-west-2 --name $CLUSTER_2_NAME
+
+export CTX_CLUSTER1=`aws eks describe-cluster --name $CLUSTER_1_NAME | jq -r '.cluster.arn'`
+export CTX_CLUSTER2=`aws eks describe-cluster --name $CLUSTER_2_NAME | jq -r '.cluster.arn'`

--- a/patterns/multi-cluster-multi-primary/cert-rotation/single-cluster.yaml
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/single-cluster.yaml
@@ -1,0 +1,84 @@
+# This playbook would rotate the CA certs on a single EKS cluster
+- name: Istio on EKS CA Cert Rotation
+  hosts: localhost
+  tasks:
+    # --------------------------------------------------------------------------
+    # Capture the cacerts secrets in the istio-system namespace
+    # --------------------------------------------------------------------------
+    - name: Ensure that the cacerts secret in istio-system exists
+      kubernetes.core.k8s:
+        state: present
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_ctx }}"
+      register: eks_cacerts_secret
+    - name: Capture the cacerts secret in istio-system exists in EKS 1
+      ansible.builtin.copy:
+        dest: files/eks_cacerts_secret.yaml
+        content: "{{ eks_cacerts_secret.result }}"
+        mode: '0755'
+    # --------------------------------------------------------------------------
+    # Create a new private key and a self-signed cert
+    # --------------------------------------------------------------------------
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: files/root-cert.key
+    - name: Create certificate signing request (CSR) for self-signed certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: files/root-cert.key
+        common_name: istio.io
+      register: csr
+    - name: Create self-signed certificate from CSR
+      community.crypto.x509_certificate:
+        path: files/root-cert.pem
+        csr_content: "{{ csr.csr }}"
+        privatekey_path: files/root-cert.key
+        provider: selfsigned
+    # --------------------------------------------------------------------------
+    # Create a new root certificate by merging existing root cert with newly
+    # created root certificate
+    # --------------------------------------------------------------------------
+    - name: Display the EKS root-cert.pem
+      ansible.builtin.debug:
+        msg: "{{ eks_cacerts_secret.result.data[\"root-cert.pem\"] | b64decode }}"
+        verbosity: 1
+    - name: Capture the EKS root-cert.pem as string
+      ansible.builtin.set_fact:
+        eks_root_cert: "{{ eks_cacerts_secret.result.data[\"root-cert.pem\"] | b64decode }}"
+    - name: Capture the new root-cert.pem as string
+      ansible.builtin.set_fact:
+        new_root_cert: "{{ lookup('file', 'files/root-cert.pem') }}"
+    - name: Create a new certificate by concatenating the above two strings
+      ansible.builtin.copy:
+        dest: files/new-root-cert.pem
+        content: "{{ eks_root_cert + new_root_cert }}"
+        mode: '0400'
+    # --------------------------------------------------------------------------
+    # Replace the cacerts in istio-system namespace
+    # --------------------------------------------------------------------------
+    - name: Ensure that the cacerts secret in istio-system doesn't exist
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        namespace: istio-system
+        name: cacerts
+        context: "{{ eks_ctx }}"
+    - name: Create the cacerts in istio-system namespace
+      kubernetes.core.k8s:
+        state: present
+        context: "{{ eks_ctx }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: cacerts
+            namespace: istio-system
+          data:
+            ca-cert.pem: "{{ eks_cacerts_secret.result.data[\"ca-cert.pem\"] }}"
+            ca-key.pem: "{{ eks_cacerts_secret.result.data[\"ca-key.pem\"] }}"
+            cert-chain.pem: "{{ eks_cacerts_secret.result.data[\"cert-chain.pem\"] }}"
+            root-cert.pem: "{{ lookup('file', 'files/new-root-cert.pem') | b64encode }}"

--- a/patterns/multi-cluster-multi-primary/cert-rotation/single-cluster.yaml
+++ b/patterns/multi-cluster-multi-primary/cert-rotation/single-cluster.yaml
@@ -18,7 +18,7 @@
       ansible.builtin.copy:
         dest: files/eks_cacerts_secret.yaml
         content: "{{ eks_cacerts_secret.result }}"
-        mode: '0755'
+        mode: '0600'
     # --------------------------------------------------------------------------
     # Create a new private key and a self-signed cert
     # --------------------------------------------------------------------------

--- a/patterns/multi-cluster-multi-primary/multi-network/eks_1.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/eks_1.tf
@@ -32,7 +32,7 @@ provider "helm" {
 
 module "vpc_1" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0.1"
 
   name = "${local.eks_1_name}-vpc"
   cidr = local.vpc_cidr
@@ -72,7 +72,7 @@ module "vpc_1" {
 
 module "eks_1" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.33.1"
+  version = "~> 20.37.1"
 
   cluster_name                             = local.eks_1_name
   cluster_version                          = local.eks_cluster_version
@@ -178,7 +178,7 @@ resource "tls_locally_signed_cert" "intermediate_ca_cert_1" {
 
 module "eks_1_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.20.0"
+  version = "~> 1.21.0"
 
   cluster_name      = module.eks_1.cluster_name
   cluster_endpoint  = module.eks_1.cluster_endpoint
@@ -201,6 +201,16 @@ module "eks_1_addons" {
       name          = "istiod"
       namespace     = kubernetes_namespace_v1.istio_system_1.metadata[0].name
 
+      # This specific setting is unique as it could be run as the other values
+      # shown below because of the quotation marks which need to be retained
+      values = [<<EOT
+      meshConfig:
+        defaultConfig:
+          proxyMetadata:
+            PROXY_CONFIG_XDS_AGENT = "true"
+      EOT
+      ]
+
       set = [
         {
           name  = "meshConfig.accessLogFile"
@@ -221,6 +231,14 @@ module "eks_1_addons" {
         {
           name  = "gateways.istio-ingressgateway.injectionTemplate"
           value = "gateway"
+        },
+        {
+          name  = "env.AUTO_RELOAD_PLUGIN_CERTS"
+          value = "true"
+        },
+        {
+          name  = "env.ISTIO_MULTIROOT_MESH"
+          value = "true"
         }
       ]
     }

--- a/patterns/multi-cluster-multi-primary/multi-network/eks_1.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/eks_1.tf
@@ -32,7 +32,7 @@ provider "helm" {
 
 module "vpc_1" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 6.0.1"
+  version = "~> 5.21.0"
 
   name = "${local.eks_1_name}-vpc"
   cidr = local.vpc_cidr
@@ -201,14 +201,16 @@ module "eks_1_addons" {
       name          = "istiod"
       namespace     = kubernetes_namespace_v1.istio_system_1.metadata[0].name
 
-      # This specific setting is unique as it could be run as the other values
-      # shown below because of the quotation marks which need to be retained
-      values = [<<EOT
-      meshConfig:
-        defaultConfig:
-          proxyMetadata:
-            PROXY_CONFIG_XDS_AGENT = "true"
-      EOT
+      values = [
+        yamlencode({
+          meshConfig = {
+            defaultConfig = {
+              proxyMetadata = {
+                PROXY_CONFIG_XDS_AGENT = "true"
+              }
+            }
+          }
+        }),
       ]
 
       set = [

--- a/patterns/multi-cluster-multi-primary/multi-network/eks_2.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/eks_2.tf
@@ -32,7 +32,7 @@ provider "helm" {
 
 module "vpc_2" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 6.0.1"
+  version = "~> 5.21.0"
 
   name = "${local.eks_2_name}-vpc"
   cidr = local.vpc_2_cidr
@@ -178,7 +178,7 @@ resource "tls_locally_signed_cert" "intermediate_ca_cert_2" {
 
 module "eks_2_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.21.0"
+  version = "~> 1.16.0"
 
   cluster_name      = module.eks_2.cluster_name
   cluster_endpoint  = module.eks_2.cluster_endpoint
@@ -203,13 +203,18 @@ module "eks_2_addons" {
 
       # This specific setting is unique as it could be run as the other values
       # shown below because of the quotation marks which need to be retained
-      values = [<<EOT
-      meshConfig:
-        defaultConfig:
-          proxyMetadata:
-            PROXY_CONFIG_XDS_AGENT = "true"
-      EOT
+      values = [
+        yamlencode({
+          meshConfig = {
+            defaultConfig = {
+              proxyMetadata = {
+                PROXY_CONFIG_XDS_AGENT = "true"
+              }
+            }
+          }
+        }),
       ]
+
 
       set = [
         {

--- a/patterns/multi-cluster-multi-primary/multi-network/eks_2.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/eks_2.tf
@@ -178,7 +178,7 @@ resource "tls_locally_signed_cert" "intermediate_ca_cert_2" {
 
 module "eks_2_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.16.0"
+  version = "~> 1.21.0"
 
   cluster_name      = module.eks_2.cluster_name
   cluster_endpoint  = module.eks_2.cluster_endpoint

--- a/patterns/multi-cluster-multi-primary/multi-network/locals.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/locals.tf
@@ -9,9 +9,9 @@ locals {
   # EKS specific settings
   eks_1_name          = "eks-1"
   eks_2_name          = "eks-2"
-  eks_1_IPv6          = true
-  eks_2_IPv6          = true
-  eks_cluster_version = "1.32"
+  eks_1_IPv6          = false
+  eks_2_IPv6          = false
+  eks_cluster_version = "1.33"
 
   # Istio specific settings
   meshID       = "mesh1"
@@ -21,7 +21,7 @@ locals {
   clusterName2 = "cluster2"
 
   istio_chart_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_chart_version = "1.24.3"
+  istio_chart_version = "1.26.2"
 
   tags = {
     GithubRepo = "github.com/aws_ia/terraform-aws-eks-blueprints"

--- a/patterns/multi-cluster-multi-primary/multi-network/versions.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 3.0.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 2.37.1"
     }
   }
 

--- a/patterns/multi-cluster-multi-primary/multi-network/versions.tf
+++ b/patterns/multi-cluster-multi-primary/multi-network/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 5.100.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.0.2"
+      version = ">= 2.0, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/multi-cluster-multi-primary/single-network/eks_1.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/eks_1.tf
@@ -222,12 +222,16 @@ module "eks_1_addons" {
 
       # This specific setting is unique as it could be run as the other values
       # shown below because of the quotation marks which need to be retained
-      values = [<<EOT
-      meshConfig:
-        defaultConfig:
-          proxyMetadata:
-            PROXY_CONFIG_XDS_AGENT = "true"
-      EOT
+      values = [
+        yamlencode({
+          meshConfig = {
+            defaultConfig = {
+              proxyMetadata = {
+                PROXY_CONFIG_XDS_AGENT = "true"
+              }
+            }
+          }
+        }),
       ]
 
       set = [

--- a/patterns/multi-cluster-multi-primary/single-network/eks_1.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/eks_1.tf
@@ -32,7 +32,7 @@ provider "helm" {
 
 module "eks_1" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.33.1"
+  version = "~> 20.37.1"
 
   cluster_name                   = local.eks_1_name
   cluster_version                = local.eks_cluster_version
@@ -194,7 +194,7 @@ resource "tls_locally_signed_cert" "intermediate_ca_cert_1" {
 
 module "eks_1_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.20.0"
+  version = "~> 1.21.0"
 
   cluster_name      = module.eks_1.cluster_name
   cluster_endpoint  = module.eks_1.cluster_endpoint
@@ -220,6 +220,16 @@ module "eks_1_addons" {
       name          = "istiod"
       namespace     = kubernetes_namespace_v1.istio_system_1.metadata[0].name
 
+      # This specific setting is unique as it could be run as the other values
+      # shown below because of the quotation marks which need to be retained
+      values = [<<EOT
+      meshConfig:
+        defaultConfig:
+          proxyMetadata:
+            PROXY_CONFIG_XDS_AGENT = "true"
+      EOT
+      ]
+
       set = [
         {
           name  = "meshConfig.accessLogFile"
@@ -240,6 +250,14 @@ module "eks_1_addons" {
         {
           name  = "gateways.istio-ingressgateway.injectionTemplate"
           value = "gateway"
+        },
+        {
+          name  = "env.AUTO_RELOAD_PLUGIN_CERTS"
+          value = "true"
+        },
+        {
+          name  = "env.ISTIO_MULTIROOT_MESH"
+          value = "true"
         }
       ]
     }

--- a/patterns/multi-cluster-multi-primary/single-network/eks_2.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/eks_2.tf
@@ -222,12 +222,16 @@ module "eks_2_addons" {
 
       # This specific setting is unique as it could be run as the other values
       # shown below because of the quotation marks which need to be retained
-      values = [<<EOT
-      meshConfig:
-        defaultConfig:
-          proxyMetadata:
-            PROXY_CONFIG_XDS_AGENT = "true"
-      EOT
+      values = [
+        yamlencode({
+          meshConfig = {
+            defaultConfig = {
+              proxyMetadata = {
+                PROXY_CONFIG_XDS_AGENT = "true"
+              }
+            }
+          }
+        }),
       ]
 
       set = [

--- a/patterns/multi-cluster-multi-primary/single-network/eks_2.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/eks_2.tf
@@ -32,7 +32,7 @@ provider "helm" {
 
 module "eks_2" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.33.1"
+  version = "~> 20.37.1"
 
   cluster_name                   = local.eks_2_name
   cluster_version                = local.eks_cluster_version
@@ -194,7 +194,7 @@ resource "tls_locally_signed_cert" "intermediate_ca_cert_2" {
 
 module "eks_2_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.20.0"
+  version = "~> 1.21.0"
 
   cluster_name      = module.eks_2.cluster_name
   cluster_endpoint  = module.eks_2.cluster_endpoint
@@ -220,6 +220,16 @@ module "eks_2_addons" {
       name          = "istiod"
       namespace     = kubernetes_namespace_v1.istio_system_2.metadata[0].name
 
+      # This specific setting is unique as it could be run as the other values
+      # shown below because of the quotation marks which need to be retained
+      values = [<<EOT
+      meshConfig:
+        defaultConfig:
+          proxyMetadata:
+            PROXY_CONFIG_XDS_AGENT = "true"
+      EOT
+      ]
+
       set = [
         {
           name  = "meshConfig.accessLogFile"
@@ -240,6 +250,14 @@ module "eks_2_addons" {
         {
           name  = "gateways.istio-ingressgateway.injectionTemplate"
           value = "gateway"
+        },
+        {
+          name  = "env.AUTO_RELOAD_PLUGIN_CERTS"
+          value = "true"
+        },
+        {
+          name  = "env.ISTIO_MULTIROOT_MESH"
+          value = "true"
         }
       ]
     }

--- a/patterns/multi-cluster-multi-primary/single-network/locals.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/locals.tf
@@ -7,11 +7,11 @@ locals {
   vpc_IPv6 = local.eks_1_IPv6 || local.eks_2_IPv6
 
   # EKS specific settings
-  eks_1_IPv6          = true
-  eks_2_IPv6          = true
+  eks_1_IPv6          = false
+  eks_2_IPv6          = false
   eks_1_name          = "eks-1"
   eks_2_name          = "eks-2"
-  eks_cluster_version = "1.32"
+  eks_cluster_version = "1.33"
 
   # Istio specific settings
   meshID       = "mesh1"
@@ -20,7 +20,7 @@ locals {
   clusterName2 = "cluster2"
 
   istio_chart_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_chart_version = "1.24.3"
+  istio_chart_version = "1.26.2"
 
   tags = {
     GithubRepo = "github.com/aws_ia/terraform-aws-eks-blueprints"

--- a/patterns/multi-cluster-multi-primary/single-network/versions.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 3.0.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 2.37.1"
     }
   }
 

--- a/patterns/multi-cluster-multi-primary/single-network/versions.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 5.100.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.0.2"
+      version = ">= 2.0, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/multi-cluster-multi-primary/single-network/vpc.tf
+++ b/patterns/multi-cluster-multi-primary/single-network/vpc.tf
@@ -4,7 +4,7 @@
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.19.0"
+  version = "~> 5.21.0"
 
   name = "shared-vpc"
   cidr = local.vpc_cidr


### PR DESCRIPTION
*Resolves Issue #112*

*Description of changes:*

1. Changes to the `istiod` deployment to enable multi-root CA and configuration setting for Pilot to update the envoy proxies as soon as `cacerts` has been updated
2. Addition of a folder and tool to update the Root CA cert with Ansible automation
3. Update of various Terraform module versions to newer ones that do not result in a breakage 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
