### PR TITLE
Update Istio Root CA renewal

### DIFF
--- a/modules/04-security/terraform/istio.tf
+++ b/modules/04-security/terraform/istio.tf
@@ -95,7 +95,7 @@ resource "kubectl_manifest" "istio_ca_cert" {
         kind  = "AWSPCAClusterIssuer"
         name  = "root-ca"
       }
-      renewBefore = "162h0m0s" # 6h less than 7d
+      renewBefore = "6h0m0s" # 6h less than 7d
       usages = [
         "server auth",
         "client auth"


### PR DESCRIPTION
Resolves Issue https://github.com/aws-samples/istio-on-eks/issues/114

*Description of changes:*

- Update [renewBefore](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Certificate) with correct value for "6h less than 7d"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
